### PR TITLE
fix seal and unseal of nested and recursive structures, strings (char slices)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 zig-out/
 .zig-cache/
-*.tar.gz
-tmp/
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+zig-out/
+.zig-cache/
+*.tar.gz
+tmp/
+.DS_Store

--- a/build.zig
+++ b/build.zig
@@ -37,7 +37,6 @@ pub fn build(b: *std.Build) void {
         .target = target,
         .optimize = optimize,
     });
-    // main_tests.setBuildMode(mode);
 
     const run_library_tests = b.addRunArtifact(library_tests);
 

--- a/build.zig
+++ b/build.zig
@@ -1,17 +1,49 @@
 const std = @import("std");
 
-pub fn build(b: *std.build.Builder) void {
-    // Standard release options allow the person running `zig build` to select
-    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall.
-    const mode = b.standardReleaseOptions();
+pub fn build(b: *std.Build) void {
+    // Standard target options allows the person running `zig build` to choose
+    // what target to build for. Here we do not override the defaults, which
+    // means any target is allowed, and the default is native. Other options
+    // for restricting supported target set are available.
+    const target = b.standardTargetOptions(.{});
 
-    const lib = b.addStaticLibrary("zig_compact", "src/main.zig");
-    lib.setBuildMode(mode);
-    lib.install();
+    // Standard optimization options allow the person running `zig build` to select
+    // between Debug, ReleaseSafe, ReleaseFast, and ReleaseSmall. Here we do not
+    // set a preferred release mode, allowing the user to decide how to optimize.
+    const optimize = b.standardOptimizeOption(.{});
 
-    const main_tests = b.addTest("src/main.zig");
-    main_tests.setBuildMode(mode);
+    _ = b.addModule("zig_compact", .{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
 
+    const lib = b.addStaticLibrary(.{
+        .name = "zig_compact",
+        // In this case the main source file is merely a path, however, in more
+        // complicated build scripts, this could be a generated file.
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+
+    // This declares intent for the library to be installed into the standard
+    // location when the user invokes the "install" step (the default step when
+    // running `zig build`).
+    b.installArtifact(lib);
+
+    const library_tests = b.addTest(.{
+        .root_source_file = b.path("src/main.zig"),
+        .target = target,
+        .optimize = optimize,
+    });
+    // main_tests.setBuildMode(mode);
+
+    const run_library_tests = b.addRunArtifact(library_tests);
+
+    // Similar to creating the run step earlier, this exposes a `test` step to
+    // the `zig build --help` menu, providing a way for the user to request
+    // running the unit tests.
     const test_step = b.step("test", "Run library tests");
-    test_step.dependOn(&main_tests.step);
+    test_step.dependOn(&run_library_tests.step);
 }

--- a/src/compact.zig
+++ b/src/compact.zig
@@ -17,7 +17,7 @@ pub fn ComplexType(comptime T: type) bool {
 
         .Struct => |s| {
             inline for (s.fields) |field| {
-                if (ComplexType(field.field_type)) {
+                if (ComplexType(field.type)) {
                     return true;
                 }
             }
@@ -26,7 +26,7 @@ pub fn ComplexType(comptime T: type) bool {
 
         .Union => |u| {
             inline for (u.fields) |field| {
-                if (ComplexType(field.field_type)) {
+                if (ComplexType(field.type)) {
                     return true;
                 }
             }
@@ -75,7 +75,7 @@ pub fn repair(comptime T: type, value: T, allocator: Allocator) AllocatorError!v
 
                 .Slice => {
                     const sliceElementType = @TypeOf(value.*[0]);
-                    var duplicateSlice = try allocator.dupe(sliceElementType, @ptrCast([]const sliceElementType, value.*));
+                    var duplicateSlice = try allocator.dupe(sliceElementType, @as([]const sliceElementType, @ptrCast(value.*)));
 
                     if (ComplexType(sliceElementType)) {
                         var index: usize = 0;
@@ -98,7 +98,7 @@ pub fn repair(comptime T: type, value: T, allocator: Allocator) AllocatorError!v
 
         .Struct => |s| {
             inline for (s.fields) |field| {
-                var fieldPtr = &@field(value.*, field.name);
+                const fieldPtr = &@field(value.*, field.name);
                 try repair(@TypeOf(fieldPtr), fieldPtr, allocator);
             }
         },
@@ -116,7 +116,7 @@ pub fn repair(comptime T: type, value: T, allocator: Allocator) AllocatorError!v
         .Union => |u| {
             if (u.tag_type == null) {
                 inline for (u.fields) |field| {
-                    if (ComplexType(field.field_type)) {
+                    if (ComplexType(field.type)) {
                         // NOTE compile time error - we can't ensure correct duplication
                         // for untagged unions with pointers, as we don't know which field to copy.
                         @compileError("Cannot repair an untagged union with complex fields!");
@@ -128,7 +128,7 @@ pub fn repair(comptime T: type, value: T, allocator: Allocator) AllocatorError!v
                     if (std.mem.eql(u8, @tagName(value.*), field.name)) {
                         // TODO this may be a problem if we actually allocate this structure on the stack.
                         // However, I don't know how else to synthesis a pointer type from a type.
-                        const variantPtr: *field.field_type = undefined;
+                        const variantPtr: *field.type = undefined;
                         //var variantPtr = @ptrCast(@TypeOf(&variant), value);
                         try repair(@TypeOf(variantPtr), variantPtr, allocator);
                     }
@@ -141,7 +141,7 @@ pub fn repair(comptime T: type, value: T, allocator: Allocator) AllocatorError!v
                 if (value.* != null) {
                     // I'm not sure about this- can we use a pointer to the inner part of an optional
                     // even if that optional is not a pointer?
-                    try repair(*o.child, @ptrCast(*o.child, &value.*), allocator);
+                    try repair(*o.child, @as(*o.child, @ptrCast(&value.*)), allocator);
                 }
             }
         },
@@ -167,8 +167,8 @@ pub fn repair(comptime T: type, value: T, allocator: Allocator) AllocatorError!v
 pub fn dupe(comptime T: type, value: T, allocator: Allocator) AllocatorError!T {
     const pointerInfo = @typeInfo(T).Pointer;
     const child = pointerInfo.child;
-    var duplicateSlice = try allocator.dupe(child, @ptrCast([*]const child, value)[0..1]);
-    var duplicate = @ptrCast(T, duplicateSlice);
+    const duplicateSlice = try allocator.dupe(child, @as([*]const child, @ptrCast(value))[0..1]);
+    const duplicate = @as(T, @ptrCast(duplicateSlice));  
 
     try repair(T, duplicate, allocator);
 
@@ -178,11 +178,11 @@ pub fn dupe(comptime T: type, value: T, allocator: Allocator) AllocatorError!T {
 test "compact simple pointer" {
     var heapAllocator = std.heap.GeneralPurposeAllocator(.{}){};
     var allocator = heapAllocator.allocator();
-    var ptr: *u32 = try allocator.create(u32);
+    const ptr: *u32 = try allocator.create(u32);
     defer allocator.destroy(ptr);
 
     ptr.* = 0x01234567;
-    var dupePtr = try compact(*u32, ptr, allocator);
+    const dupePtr = try compact(*u32, ptr, allocator);
     try std.testing.expect(ptr != dupePtr);
     try std.testing.expectEqual(ptr.*, dupePtr.*);
 }
@@ -190,13 +190,13 @@ test "compact simple pointer" {
 test "compact simple array" {
     var heapAllocator = std.heap.GeneralPurposeAllocator(.{}){};
     var allocator = heapAllocator.allocator();
-    var ptr: *[3]u32 = try allocator.create([3]u32);
+    const ptr: *[3]u32 = try allocator.create([3]u32);
     defer allocator.destroy(ptr);
 
     ptr.*[0] = 1;
     ptr.*[1] = 2;
     ptr.*[2] = 3;
-    var dupePtr = try compact(*[3]u32, ptr, allocator);
+    const dupePtr = try compact(*[3]u32, ptr, allocator);
     try std.testing.expect(ptr != dupePtr);
     try std.testing.expectEqual(ptr.*[0], dupePtr.*[0]);
     try std.testing.expectEqual(ptr.*[1], dupePtr.*[1]);
@@ -207,13 +207,13 @@ test "compact simple struct" {
     const S = struct { a: u64, b: u32, c: u8 };
     var heapAllocator = std.heap.GeneralPurposeAllocator(.{}){};
     var allocator = heapAllocator.allocator();
-    var ptr: *S = try allocator.create(S);
+    const ptr: *S = try allocator.create(S);
     defer allocator.destroy(ptr);
 
     ptr.a = 1;
     ptr.b = 2;
     ptr.c = 3;
-    var dupePtr = try compact(*S, ptr, allocator);
+    const dupePtr = try compact(*S, ptr, allocator);
     try std.testing.expect(ptr != dupePtr);
     try std.testing.expectEqual(ptr.a, dupePtr.a);
     try std.testing.expectEqual(ptr.b, dupePtr.b);
@@ -224,11 +224,11 @@ test "compact simple union" {
     const U = union(enum) { a: u64, b: u32, c: u8 };
     var heapAllocator = std.heap.GeneralPurposeAllocator(.{}){};
     var allocator = heapAllocator.allocator();
-    var ptr: *U = try allocator.create(U);
+    const ptr: *U = try allocator.create(U);
     defer allocator.destroy(ptr);
 
     ptr.* = U{ .a = 1 };
-    var dupePtr = try compact(*U, ptr, allocator);
+    const dupePtr = try compact(*U, ptr, allocator);
     try std.testing.expect(ptr != dupePtr);
     try std.testing.expectEqual(ptr.a, dupePtr.a);
 }
@@ -236,16 +236,16 @@ test "compact simple union" {
 test "compact simple optional" {
     var heapAllocator = std.heap.GeneralPurposeAllocator(.{}){};
     var allocator = heapAllocator.allocator();
-    var ptr: *?u32 = try allocator.create(?u32);
+    const ptr: *?u32 = try allocator.create(?u32);
     defer allocator.destroy(ptr);
 
     ptr.* = 1;
-    var dupePtr = try compact(*?u32, ptr, allocator);
+    const dupePtr = try compact(*?u32, ptr, allocator);
     try std.testing.expect(ptr != dupePtr);
     try std.testing.expectEqual(ptr.*.?, dupePtr.*.?);
 
     ptr.* = null;
-    var dupePtrNull = try compact(*?u32, ptr, allocator);
+    const dupePtrNull = try compact(*?u32, ptr, allocator);
     try std.testing.expect(ptr != dupePtrNull);
     try std.testing.expectEqual(ptr.*, dupePtrNull.*);
 }
@@ -253,13 +253,13 @@ test "compact simple optional" {
 test "compact simple slice" {
     var heapAllocator = std.heap.GeneralPurposeAllocator(.{}){};
     var allocator = heapAllocator.allocator();
-    var ptr: *[3]u32 = try allocator.create([3]u32);
+    const ptr: *[3]u32 = try allocator.create([3]u32);
     defer allocator.destroy(ptr);
 
     ptr.*[0] = 1;
     ptr.*[1] = 2;
     ptr.*[2] = 3;
-    var dupePtr = try compact(*[3]u32, ptr, allocator);
+    const dupePtr = try compact(*[3]u32, ptr, allocator);
     try std.testing.expect(ptr != dupePtr);
     try std.testing.expect(std.meta.eql(ptr.*, dupePtr.*));
     try std.testing.expectEqual(ptr.*[0], dupePtr.*[0]);
@@ -279,7 +279,7 @@ test "compact complex struct" {
     var heapAllocator = std.heap.GeneralPurposeAllocator(.{}){};
     var allocator = heapAllocator.allocator();
 
-    var ptr: *S2 = try allocator.create(S2);
+    const ptr: *S2 = try allocator.create(S2);
     defer allocator.destroy(ptr);
 
     ptr.s1 = try allocator.create(S1);
@@ -308,12 +308,12 @@ test "compact complex struct" {
     ptr.s1_array_ptrs[2].* = ptr.s1_array[2];
 
     ptr.s1_slice = (try allocator.create([3]S1))[0..];
-    defer allocator.destroy(ptr.s1_slice.ptr);
+    defer allocator.free(ptr.s1_slice);
     ptr.s1_slice[0] = ptr.s1.*;
     ptr.s1_slice[1] = ptr.s1.*;
     ptr.s1_slice[2] = ptr.s1.*;
 
-    var dupePtr = try compact(*S2, ptr, allocator);
+    const dupePtr = try compact(*S2, ptr, allocator);
     try std.testing.expect(ptr != dupePtr);
     try std.testing.expect(ptr.*.s1 != dupePtr.*.s1);
     try std.testing.expect(std.meta.eql(ptr.s1_array, dupePtr.s1_array));

--- a/src/seal.zig
+++ b/src/seal.zig
@@ -1,5 +1,4 @@
 const std = @import("std");
-const trait = std.meta.trait;
 const testing = std.testing;
 const Allocator = std.mem.Allocator;
 const AllocatorError = std.mem.Allocator.Error;
@@ -100,8 +99,8 @@ pub fn seal(comptime T: type, ptr: T, offset: usize, size: usize) SealError!void
                 inline for (u.fields) |field| {
                     // Compare name to find variant in field list
                     if (std.mem.eql(u8, @tagName(ptr.*), field.name)) {
-                        const variantPtr: *field.type = undefined;
-                        try seal(@TypeOf(variantPtr), variantPtr, offset, size);
+                        const variant_ptr: *field.type = @constCast(&@field(ptr.*, field.name));
+                        try seal(@TypeOf(variant_ptr), variant_ptr, offset, size);
                     }
                 }
             }
@@ -112,7 +111,7 @@ pub fn seal(comptime T: type, ptr: T, offset: usize, size: usize) SealError!void
                 if (ptr.* != null) {
                     // I'm not sure about this- can we use a pointer to the inner part of an optional
                     // even if that optional is not a pointer?
-                    try seal(*o.child, @as(*o.child, @ptrCast(&ptr.*.?)), offset, size);
+                    try seal(*o.child, @as(*o.child, @constCast(@ptrCast(&ptr.*.?))), offset, size);
                 }
             }
         },
@@ -247,8 +246,8 @@ pub fn unseal(comptime T: type, ptr: T, offset: usize, size: usize) SealError!vo
                 inline for (u.fields) |field| {
                     // Compare name to find variant in field list
                     if (std.mem.eql(u8, @tagName(ptr.*), field.name)) {
-                        const variantPtr: *field.type = undefined;
-                        try unseal(@TypeOf(variantPtr), variantPtr, offset, size);
+                        const variant_ptr: *field.type = @constCast(&@field(ptr.*, field.name));
+                        try unseal(@TypeOf(variant_ptr), variant_ptr, offset, size);
                     }
                 }
             }
@@ -259,7 +258,7 @@ pub fn unseal(comptime T: type, ptr: T, offset: usize, size: usize) SealError!vo
                 if (ptr.* != null) {
                     // I'm not sure about this- can we use a pointer to the inner part of an optional
                     // even if that optional is not a pointer?
-                    try unseal(*o.child, @as(*o.child, @ptrCast(&ptr.*.?)), offset, size);
+                    try unseal(*o.child, @as(*o.child, @constCast(@ptrCast(&ptr.*.?))), offset, size);
                 }
             }
         },
@@ -367,4 +366,300 @@ test "seal and unseal with buffer" {
     try std.testing.expectEqual(s2_ptr.*.c.*, new_ptr.*.c.*);
 
     try std.testing.expectEqual(s2_ptr.*.e.?.*, new_ptr.*.e.?.*);
+}
+
+test "seal and unseal union with string field with buffer" {
+    const U = union(enum) { a: u64, b: []const u8, c: u32 };
+
+    const buffer_size = 40;
+    var buffer align(8) = [_]u8{0} ** buffer_size;
+
+    const allocator = std.testing.allocator;
+
+    const u_ptr: *U = try allocator.create(U);
+
+    u_ptr.* = U{ .b = "lorem ipsum" };
+    _ = try seal_into_buffer(*U, u_ptr, buffer[0..]);
+
+    // Make sure data exists only in the buffer
+    allocator.destroy(u_ptr);
+
+    const new_ptr = try unseal_from_buffer(*U, buffer[0..], allocator);
+    defer {
+        allocator.free(new_ptr.b);
+        allocator.destroy(new_ptr);
+    }
+
+    // Make sure data exists only in the new_ptr
+    inline for (&buffer) |*i| {
+        i.* = 0;
+    }
+
+    try std.testing.expect(u_ptr != new_ptr);
+    try std.testing.expectEqualStrings("lorem ipsum", new_ptr.b);
+}
+
+const E = enum { a, b, c };
+test "seal and unseal structure with enum field with buffer" {
+    const S = struct {
+        a: E,
+        b: u8,
+    };
+
+    const buffer_size = 2;
+    var buffer align(8) = [_]u8{0} ** buffer_size;
+
+    const allocator = std.testing.allocator;
+
+    var s_ptr = try allocator.create(S);
+
+    s_ptr.a = E.c;
+    s_ptr.b = 201;
+
+    _ = try seal_into_buffer(*S, s_ptr, buffer[0..]);
+
+    // Make sure data exists only in the buffer
+    allocator.destroy(s_ptr);
+
+    const new_ptr = try unseal_from_buffer(*S, buffer[0..], allocator);
+    defer allocator.destroy(new_ptr);
+
+    try std.testing.expectEqual(E.c, new_ptr.*.a);
+    try std.testing.expectEqual(201, new_ptr.*.b);
+}
+
+test "seal and unseal structure with an optional slice of structures with buffer" {
+    const S1 = struct {
+        a: u32,
+        b: u8,
+    };
+    const S2 = struct { a: u32, b: ?[]const S1 = null };
+
+    const buffer_size = 40;
+    var buffer align(8) = [_]u8{0} ** buffer_size;
+
+    const allocator = std.testing.allocator;
+
+    var children = std.ArrayList(S1).init(allocator);
+    defer children.deinit();
+
+    try children.append(S1{
+        .a = 4_294_967_295,
+        .b = 'A',
+    });
+
+    var s2_ptr = try allocator.create(S2);
+
+    s2_ptr.a = 2_147_483_647;
+    s2_ptr.b = try children.toOwnedSlice();
+
+    _ = try seal_into_buffer(*S2, s2_ptr, buffer[0..]);
+
+    const child_ptr = &s2_ptr.b.?[0];
+    // Make sure data exists only in the buffer
+    allocator.free(s2_ptr.b.?);
+    allocator.destroy(s2_ptr);
+
+    const new_ptr = try unseal_from_buffer(*S2, buffer[0..], allocator);
+    defer {
+        allocator.free(new_ptr.b.?);
+        allocator.destroy(new_ptr);
+    }
+
+    // Make sure data exists only in the new_ptr
+    inline for (&buffer) |*i| {
+        i.* = 0;
+    }
+
+    try std.testing.expectEqual(2_147_483_647, new_ptr.a);
+    try std.testing.expect(child_ptr != &new_ptr.b.?[0]);
+    try std.testing.expectEqual(4_294_967_295, new_ptr.b.?[0].a);
+    try std.testing.expectEqual('A', new_ptr.b.?[0].b);
+}
+
+const R1 = struct {
+    l: []const u8,
+    children: ?[]const R1 = null,
+
+    pub fn deinit(self: *const R1, allocator: std.mem.Allocator) void {
+        const children = self.children orelse return;
+        for (children) |*child| {
+            child.deinit(allocator);
+        }
+
+        allocator.free(children);
+    }
+
+    pub fn deinitDeserialized(self: *const R1, allocator: std.mem.Allocator) void {
+        allocator.free(self.l);
+
+        const children = self.children orelse return;
+        for (children) |*child| {
+            child.deinitDeserialized(allocator);
+        }
+
+        allocator.free(children);
+    }
+};
+test "seal and unseal recursive structure with buffer" {
+    const buffer_size = 240;
+    var buffer align(8) = [_]u8{0} ** buffer_size;
+
+    const allocator = std.testing.allocator;
+
+    var children = std.ArrayList(R1).init(allocator);
+    defer children.deinit();
+
+    try children.append(R1{
+        .l = "Leaf 1",
+    });
+    try children.append(R1{
+        .l = "Leaf 2",
+    });
+
+    try children.append(R1{
+        .l = "Branch 1",
+        .children = try children.toOwnedSlice(),
+    });
+
+    try children.append(R1{
+        .l = "Branch 2",
+    });
+
+    var r_ptr: *R1 = try allocator.create(R1);
+
+    r_ptr.l = "Root";
+    r_ptr.children = try children.toOwnedSlice();
+
+    _ = try seal_into_buffer(*R1, r_ptr, buffer[0..]);
+
+    // Make sure data exists only in the buffer
+    r_ptr.deinit(allocator);
+    allocator.destroy(r_ptr);
+
+    const new_ptr: *R1 = try unseal_from_buffer(*R1, buffer[0..], allocator);
+    defer {
+        new_ptr.deinitDeserialized(allocator);
+        allocator.destroy(new_ptr);
+    }
+
+    // Make sure data exists only in the new_ptr
+    for (&buffer) |*i| {
+        i.* = 0;
+    }
+
+    try std.testing.expectEqualStrings("Root", new_ptr.l);
+
+    try std.testing.expectEqualStrings("Branch 1", new_ptr.children.?[0].l);
+    try std.testing.expectEqualStrings("Leaf 1", new_ptr.children.?[0].children.?[0].l);
+    try std.testing.expectEqualStrings("Leaf 2", new_ptr.children.?[0].children.?[1].l);
+
+    try std.testing.expectEqualStrings("Branch 2", new_ptr.children.?[1].l);
+    try std.testing.expectEqual(null, new_ptr.children.?[1].children);
+}
+
+const R2 = struct {
+    l: []const u8,
+    e: ?E = null,
+    children: ?[]const C = null,
+
+    pub fn deinit(self: *const R2, allocator: std.mem.Allocator) void {
+        const children = self.children orelse return;
+        for (children) |*child| {
+            child.deinit(allocator);
+        }
+
+        allocator.free(children);
+    }
+
+    pub fn deinitDeserialized(self: *const R2, allocator: std.mem.Allocator) void {
+        allocator.free(self.l);
+
+        const children = self.children orelse return;
+        for (children) |*child| {
+            child.deinitDeserialized(allocator);
+        }
+
+        allocator.free(children);
+    }
+};
+
+const C = union(enum) {
+    s: []const u8,
+    r: R2,
+
+    pub fn deinit(self: C, allocator: std.mem.Allocator) void {
+        switch (self) {
+            C.r => self.r.deinit(allocator),
+            else => undefined,
+        }
+    }
+
+    pub fn deinitDeserialized(self: C, allocator: std.mem.Allocator) void {
+        switch (self) {
+            C.r => self.r.deinitDeserialized(allocator),
+            C.s => allocator.free(self.s),
+        }
+    }
+};
+test "seal and unseal complex recursive union with buffer" {
+    const buffer_size = 328;
+    var buffer align(8) = [_]u8{0} ** buffer_size;
+
+    const allocator = std.testing.allocator;
+
+    var children = std.ArrayList(C).init(allocator);
+    defer children.deinit();
+
+    try children.append(C{ .s = "Leaf 1" });
+    try children.append(C{ .s = "Leaf 2" });
+
+    try children.append(C{
+        .r = R2{
+            .l = "Branch 1",
+            .e = .a,
+            .children = try children.toOwnedSlice(),
+        },
+    });
+    try children.append(C{
+        .r = R2{
+            .l = "Branch 2",
+            .e = .c,
+        },
+    });
+
+    const c_ptr = try allocator.create(C);
+
+    c_ptr.* = C{
+        .r = R2{
+            .l = "Root",
+            .e = .b,
+            .children = try children.toOwnedSlice(),
+        },
+    };
+
+    _ = try seal_into_buffer(*C, c_ptr, buffer[0..]);
+
+    c_ptr.deinit(allocator);
+    allocator.destroy(c_ptr);
+
+    const new_ptr: *C = try unseal_from_buffer(*C, buffer[0..], allocator);
+    defer {
+        new_ptr.deinitDeserialized(allocator);
+        allocator.destroy(new_ptr);
+    }
+
+    // Make sure data exists only in the new_ptr
+    inline for (&buffer) |*i| {
+        i.* = 0;
+    }
+
+    try std.testing.expectEqualStrings("Root", new_ptr.r.l);
+    try std.testing.expectEqual(.b, new_ptr.r.e);
+    try std.testing.expectEqualStrings("Branch 1", new_ptr.r.children.?[0].r.l);
+    try std.testing.expectEqual(.a, new_ptr.r.children.?[0].r.e);
+    try std.testing.expectEqualStrings("Leaf 1", new_ptr.r.children.?[0].r.children.?[0].s);
+    try std.testing.expectEqualStrings("Leaf 2", new_ptr.r.children.?[0].r.children.?[1].s);
+    try std.testing.expectEqualStrings("Branch 2", new_ptr.r.children.?[1].r.l);
+    try std.testing.expectEqual(.c, new_ptr.r.children.?[1].r.e);
 }


### PR DESCRIPTION
This commit will enable serializing and deserializing nested structures by fixing how variant_ptr gets initialized.

I also added new test cases to ensure all my use cases would be covered by this library:
- compact union with string field
- seal and unseal with buffer:
   - union with string field
   - structure with enum field
   - structure with an optional slice of structures
   - recursive structure
   - complex recursive union

For all seal and unseal new tests I used `std.testing.allocator` to detect any memory leaks.

And renamed `value` to `value_ptr` across the `repair` function and updated related references to improve reasoning about the value.